### PR TITLE
fix(HomogRotate3D): add axis vector normalization

### DIFF
--- a/transformations.go
+++ b/transformations.go
@@ -181,6 +181,7 @@ func Scale2D(scaleX, scaleY float32) Mat3 {
 //    [[ xz(1-c)-ys, yz(1-c)+xs, z^2(1-c)+c, 0 ]]
 //    [[ 0         , 0         , 0         , 1 ]]
 func HomogRotate3D(angle float32, axis *Vec3) Mat4 {
+	axis.Normalize()
 	x, y, z := axis[0], axis[1], axis[2]
 	s, c := math.Sincos(angle)
 	k := 1 - c


### PR DESCRIPTION
Normalize the axis vector parameter
Was expecting the same behaviour than the c++ glm::rotate function

I used :https://github.com/g-truc/glm/blob/b3f87720261d623986f164b2a7f6a0a938430271/glm/ext/matrix_transform.inl
for reference, they do normalize the axis vector but I don't know if the current behaviour was expected